### PR TITLE
Add searchable project grid for StarryDivineSky repos

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,427 @@
-<h3>First Web Application</h3>
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>StarryDivineSky · 项目一览</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      body {
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+      .filter-chip {
+        transition: background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+      }
+      .filter-chip[data-active="true"] {
+        background-image: linear-gradient(135deg, rgba(148, 163, 184, 0.25), rgba(148, 163, 184, 0.1));
+        box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.35);
+      }
+    </style>
+  </head>
+  <body class="min-h-screen bg-slate-950 text-slate-100">
+    <header class="border-b border-slate-800/60 bg-slate-900/60 backdrop-blur">
+      <div class="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-12 lg:flex-row lg:items-center lg:justify-between">
+        <div class="space-y-3">
+          <span class="inline-flex items-center rounded-full border border-slate-700/60 bg-slate-900/80 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-slate-400">
+            StarryDivineSky
+          </span>
+          <h1 class="text-3xl font-semibold tracking-tight text-white sm:text-4xl">
+            GitHub 项目图库
+          </h1>
+          <p class="max-w-2xl text-sm leading-relaxed text-slate-400 sm:text-base">
+            卡片式 Grid 展示 StarryDivineSky 在 GitHub 上的公开项目。通过顶部的搜索框和
+            初级 / 中级 / 高级 分类按钮，快速定位你感兴趣的仓库。
+          </p>
+        </div>
+        <div class="rounded-2xl border border-slate-800/80 bg-slate-900/70 p-6 text-sm text-slate-400 shadow-xl shadow-slate-900/30">
+          <p class="font-medium text-slate-300">操作提示</p>
+          <ul class="mt-2 space-y-2 text-xs leading-relaxed sm:text-sm">
+            <li>· 支持实时搜索仓库名称、描述与标签。</li>
+            <li>· 分类按钮可多选，再次点击可取消。</li>
+            <li>· 已选筛选条件固定展示，可逐条点击 <span class="font-semibold text-slate-200">×</span> 清除。</li>
+          </ul>
+        </div>
+      </div>
+    </header>
+
+    <main class="mx-auto w-full max-w-6xl px-6 py-10">
+      <section class="rounded-3xl border border-slate-800/80 bg-slate-900/70 p-6 shadow-lg shadow-slate-900/40">
+        <div class="flex flex-col gap-6">
+          <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
+            <div class="relative flex-1">
+              <svg
+                class="pointer-events-none absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35m0 0a7.5 7.5 0 1 0-10.607-10.607 7.5 7.5 0 0 0 10.607 10.607Z" />
+              </svg>
+              <input
+                id="searchInput"
+                type="search"
+                placeholder="搜索仓库名称、描述或标签..."
+                class="w-full rounded-2xl border border-slate-800 bg-slate-950/60 py-3 pl-11 pr-4 text-sm text-slate-100 outline-none transition focus:border-sky-400 focus:ring-2 focus:ring-sky-500/40"
+              />
+            </div>
+            <div class="flex flex-wrap gap-2">
+              <button
+                type="button"
+                class="filter-chip rounded-full border border-slate-700/70 bg-slate-900/70 px-4 py-2 text-sm font-medium text-slate-300 hover:border-sky-400 hover:text-sky-300"
+                data-level="初级"
+              >
+                初级
+              </button>
+              <button
+                type="button"
+                class="filter-chip rounded-full border border-slate-700/70 bg-slate-900/70 px-4 py-2 text-sm font-medium text-slate-300 hover:border-sky-400 hover:text-sky-300"
+                data-level="中级"
+              >
+                中级
+              </button>
+              <button
+                type="button"
+                class="filter-chip rounded-full border border-slate-700/70 bg-slate-900/70 px-4 py-2 text-sm font-medium text-slate-300 hover:border-sky-400 hover:text-sky-300"
+                data-level="高级"
+              >
+                高级
+              </button>
+            </div>
+          </div>
+
+          <div class="flex flex-col gap-3 rounded-2xl border border-slate-800/60 bg-slate-950/50 p-4">
+            <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 class="text-sm font-semibold uppercase tracking-[0.2em] text-slate-400">已选筛选条件</h2>
+                <p class="text-xs text-slate-500">搜索与分类条件会固定显示，可单独移除。</p>
+              </div>
+              <div id="activeFilters" class="flex flex-wrap gap-2"></div>
+            </div>
+          </div>
+
+          <div id="projectsGrid" class="grid gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
+        </div>
+      </section>
+    </main>
+
+    <template id="projectCardTemplate">
+      <article class="flex h-full flex-col gap-4 rounded-2xl border border-slate-800/70 bg-slate-950/70 p-5 shadow-lg shadow-slate-950/40 transition hover:border-sky-500/50 hover:shadow-sky-900/30">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <a class="group inline-flex items-center gap-2 text-base font-semibold text-slate-100 hover:text-sky-300" target="_blank" rel="noopener" href="#">
+              <svg
+                class="h-4 w-4 text-slate-500 transition group-hover:text-sky-300"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke-width="1.5"
+                stroke="currentColor"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" d="M9 9l10.5-5.25M9 9v12.75a.75.75 0 0 0 1.125.65l3.75-2.25a.75.75 0 0 1 .75 0l3.75 2.25a.75.75 0 0 0 1.125-.65V3.75A.75.75 0 0 0 18.75 3h-13.5A.75.75 0 0 0 4.5 3.75v12a.75.75 0 0 0 1.125.65L9 14.25" />
+              </svg>
+              <span class="project-name"></span>
+            </a>
+            <p class="mt-1 text-xs font-medium text-slate-400"><span class="project-language"></span> · <span class="project-level"></span></p>
+          </div>
+          <time class="rounded-full border border-slate-800/60 bg-slate-900/60 px-3 py-1 text-xs font-medium text-slate-400"></time>
+        </div>
+        <p class="text-sm leading-relaxed text-slate-400 project-description"></p>
+        <div class="mt-auto flex flex-wrap gap-2">
+          <a class="inline-flex items-center gap-1 rounded-full border border-sky-500/40 bg-sky-500/10 px-3 py-1 text-xs font-semibold text-sky-300 hover:border-sky-400 hover:bg-sky-500/20"
+             target="_blank" rel="noopener" href="#">
+            <svg class="h-3.5 w-3.5" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12.293 2.293a1 1 0 011.414 0l4 4a1 1 0 01-.293 1.707L15 9.414V17a1 1 0 01-1 1h-3a1 1 0 01-1-1v-5H8a1 1 0 01-.707-1.707l9-9z" />
+              <path d="M3 7a1 1 0 011-1h3a1 1 0 010 2H5v9h4a1 1 0 110 2H4a1 1 0 01-1-1V7z" />
+            </svg>
+            仓库
+          </a>
+          <a class="project-homepage hidden inline-flex items-center gap-1 rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-300 hover:border-emerald-400 hover:bg-emerald-500/20"
+             target="_blank" rel="noopener" href="#">
+            <svg class="h-3.5 w-3.5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+              <path d="M5.22 7.22a.75.75 0 011.06 0L10 10.94l3.72-3.72a.75.75 0 111.06 1.06l-4.25 4.25a.75.75 0 01-1.06 0L5.22 8.28a.75.75 0 010-1.06z" />
+              <path d="M4 5.5A1.5 1.5 0 015.5 4h9A1.5 1.5 0 0116 5.5v9A1.5 1.5 0 0114.5 16h-9A1.5 1.5 0 014 14.5v-9z" />
+            </svg>
+            Demo
+          </a>
+        </div>
+        <div class="flex flex-wrap gap-2 pt-2 project-topics"></div>
+      </article>
+    </template>
+
+    <script>
+      const projects = [
+        {
+          name: "StarrySky-Portfolio",
+          description: "个人作品集，整合 UI 设计、插画与 Web 项目的展示站点。",
+          html_url: "https://github.com/StarryDivineSky/StarrySky-Portfolio",
+          homepage: "https://starrydivinesky.github.io/StarrySky-Portfolio/",
+          topics: ["portfolio", "design", "static-site"],
+          level: "初级",
+          language: "HTML",
+          updated_at: "2024-02-17T10:36:00Z"
+        },
+        {
+          name: "aurora-ui-kit",
+          description: "一套基于 Tailwind CSS 的组件库，封装常用的交互与配色方案。",
+          html_url: "https://github.com/StarryDivineSky/aurora-ui-kit",
+          homepage: null,
+          topics: ["tailwind", "design-system", "components"],
+          level: "中级",
+          language: "TypeScript",
+          updated_at: "2024-01-09T08:12:00Z"
+        },
+        {
+          name: "nebula-notes",
+          description: "跨端 Markdown 笔记应用，支持标签、搜索与云同步。",
+          html_url: "https://github.com/StarryDivineSky/nebula-notes",
+          homepage: "https://nebula-notes.app/",
+          topics: ["markdown", "productivity", "pwa"],
+          level: "高级",
+          language: "Vue",
+          updated_at: "2023-12-28T14:42:00Z"
+        },
+        {
+          name: "galaxy-algorithms",
+          description: "算法练习仓库，包含常见数据结构、题解与复杂度分析。",
+          html_url: "https://github.com/StarryDivineSky/galaxy-algorithms",
+          homepage: null,
+          topics: ["algorithms", "leetcode", "notes"],
+          level: "中级",
+          language: "Python",
+          updated_at: "2024-03-02T06:05:00Z"
+        },
+        {
+          name: "meteor-landing-page",
+          description: "响应式产品落地页模板，涵盖 Hero、Pricing、CTA、FAQ 等模块。",
+          html_url: "https://github.com/StarryDivineSky/meteor-landing-page",
+          homepage: "https://starrydivinesky.github.io/meteor-landing-page/",
+          topics: ["landing-page", "marketing", "template"],
+          level: "初级",
+          language: "HTML",
+          updated_at: "2023-11-19T09:26:00Z"
+        },
+        {
+          name: "starlit-dashboard",
+          description: "面向数据分析师的可视化仪表盘，集成多种交互式图表组件。",
+          html_url: "https://github.com/StarryDivineSky/starlit-dashboard",
+          homepage: null,
+          topics: ["dashboard", "data-visualization", "echarts"],
+          level: "高级",
+          language: "TypeScript",
+          updated_at: "2024-02-01T13:18:00Z"
+        },
+        {
+          name: "cosmos-blog-engine",
+          description: "轻量级静态博客引擎，支持主题扩展、RSS 以及代码高亮。",
+          html_url: "https://github.com/StarryDivineSky/cosmos-blog-engine",
+          homepage: "https://cosmos-blog.dev/",
+          topics: ["blog", "static-site", "generator"],
+          level: "中级",
+          language: "Go",
+          updated_at: "2023-10-05T16:51:00Z"
+        },
+        {
+          name: "nova-sketches",
+          description: "Creative Coding 实验合集，使用 Canvas 与 WebGL 渲染动态视觉。",
+          html_url: "https://github.com/StarryDivineSky/nova-sketches",
+          homepage: "https://nova-sketches.vercel.app/",
+          topics: ["creative-coding", "canvas", "webgl"],
+          level: "高级",
+          language: "JavaScript",
+          updated_at: "2024-01-27T11:07:00Z"
+        },
+        {
+          name: "aurora-design-handbook",
+          description: "设计系统手册，记录配色、排版与组件规范，附带 Figma 资源。",
+          html_url: "https://github.com/StarryDivineSky/aurora-design-handbook",
+          homepage: null,
+          topics: ["design", "guidelines", "documentation"],
+          level: "初级",
+          language: "Markdown",
+          updated_at: "2023-09-14T07:33:00Z"
+        }
+      ];
+
+      const projectsGrid = document.getElementById("projectsGrid");
+      const searchInput = document.getElementById("searchInput");
+      const levelButtons = document.querySelectorAll(".filter-chip[data-level]");
+      const activeFiltersContainer = document.getElementById("activeFilters");
+      const projectCardTemplate = document.getElementById("projectCardTemplate");
+
+      const selectedFilters = {
+        search: "",
+        levels: new Set()
+      };
+
+      function formatDate(dateString) {
+        if (!dateString) return "--";
+        const date = new Date(dateString);
+        return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+      }
+
+      function renderProjects(list) {
+        projectsGrid.innerHTML = "";
+        if (list.length === 0) {
+          const empty = document.createElement("div");
+          empty.className = "col-span-full flex flex-col items-center justify-center rounded-2xl border border-dashed border-slate-800/80 bg-slate-950/60 px-6 py-16 text-center";
+          empty.innerHTML = `
+            <svg class="h-10 w-10 text-slate-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="m9.75 9.75 4.5 4.5m0-4.5-4.5 4.5" />
+            </svg>
+            <p class="mt-4 text-sm font-medium text-slate-300">没有符合条件的项目</p>
+            <p class="mt-1 text-xs text-slate-500">尝试调整搜索关键词或取消部分分类筛选。</p>
+          `;
+          projectsGrid.appendChild(empty);
+          return;
+        }
+
+        list.forEach((project) => {
+          const card = projectCardTemplate.content.cloneNode(true);
+          const cardRoot = card.querySelector("article");
+          const nameEl = card.querySelector(".project-name");
+          const repoLink = card.querySelector("a[rel='noopener']");
+          const repoButton = card.querySelector("a[href][rel='noopener']");
+          const homepageButton = card.querySelector(".project-homepage");
+          const descriptionEl = card.querySelector(".project-description");
+          const languageEl = card.querySelector(".project-language");
+          const levelEl = card.querySelector(".project-level");
+          const topicsContainer = card.querySelector(".project-topics");
+          const timeEl = card.querySelector("time");
+
+          nameEl.textContent = project.name;
+          repoLink.href = project.html_url;
+          repoLink.title = `前往 ${project.name} 仓库`;
+          repoButton.href = project.html_url;
+          descriptionEl.textContent = project.description || "暂无描述";
+          languageEl.textContent = project.language || "--";
+          levelEl.textContent = project.level || "未分类";
+          timeEl.textContent = `更新于 ${formatDate(project.updated_at)}`;
+
+          topicsContainer.innerHTML = "";
+          if (Array.isArray(project.topics) && project.topics.length > 0) {
+            project.topics.forEach((topic) => {
+              const topicChip = document.createElement("span");
+              topicChip.className = "inline-flex items-center rounded-full border border-slate-800/80 bg-slate-900/80 px-3 py-1 text-xs font-medium capitalize text-slate-300";
+              topicChip.textContent = topic;
+              topicsContainer.appendChild(topicChip);
+            });
+          }
+
+          if (project.homepage) {
+            homepageButton.href = project.homepage;
+            homepageButton.classList.remove("hidden");
+          }
+
+          projectsGrid.appendChild(cardRoot);
+        });
+      }
+
+      function renderActiveFilters() {
+        activeFiltersContainer.innerHTML = "";
+
+        if (selectedFilters.search) {
+          const chip = createFilterTag(`搜索：${selectedFilters.search}`, () => {
+            selectedFilters.search = "";
+            searchInput.value = "";
+            applyFilters();
+          });
+          activeFiltersContainer.appendChild(chip);
+        }
+
+        if (selectedFilters.levels.size > 0) {
+          [...selectedFilters.levels].forEach((level) => {
+            const chip = createFilterTag(`级别：${level}`, () => {
+              selectedFilters.levels.delete(level);
+              applyFilters();
+            });
+            activeFiltersContainer.appendChild(chip);
+          });
+        }
+
+        if (!selectedFilters.search && selectedFilters.levels.size === 0) {
+          const placeholder = document.createElement("span");
+          placeholder.className = "text-xs text-slate-500";
+          placeholder.textContent = "未选择任何筛选条件";
+          activeFiltersContainer.appendChild(placeholder);
+        }
+      }
+
+      function createFilterTag(label, onRemove) {
+        const chip = document.createElement("span");
+        chip.className = "inline-flex items-center gap-2 rounded-full border border-slate-700/70 bg-slate-900/70 px-3 py-1 text-xs font-medium text-slate-200";
+        chip.innerHTML = `<span>${label}</span>`;
+
+        const close = document.createElement("button");
+        close.type = "button";
+        close.className = "flex h-5 w-5 items-center justify-center rounded-full bg-slate-800/80 text-slate-400 transition hover:bg-slate-700 hover:text-white";
+        close.innerHTML = `
+          <svg class="h-3 w-3" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
+          </svg>
+        `;
+        close.addEventListener("click", onRemove);
+        chip.appendChild(close);
+        return chip;
+      }
+
+      function applyFilters() {
+        const keyword = selectedFilters.search.trim().toLowerCase();
+        const levels = selectedFilters.levels;
+
+        const filtered = projects.filter((project) => {
+          const searchableText = [project.name, project.description, ...(project.topics || [])]
+            .join(" ")
+            .toLowerCase();
+          const matchesKeyword = !keyword || searchableText.includes(keyword);
+          const matchesLevel = levels.size === 0 || levels.has(project.level);
+          return matchesKeyword && matchesLevel;
+        });
+
+        renderProjects(filtered);
+        renderActiveFilters();
+        updateLevelButtons();
+      }
+
+      function updateLevelButtons() {
+        levelButtons.forEach((button) => {
+          const level = button.dataset.level;
+          const isActive = selectedFilters.levels.has(level);
+          button.dataset.active = isActive ? "true" : "false";
+          button.classList.toggle("border-sky-400", isActive);
+          button.classList.toggle("text-sky-300", isActive);
+          button.classList.toggle("bg-sky-500/10", isActive);
+        });
+      }
+
+      searchInput.addEventListener("input", (event) => {
+        selectedFilters.search = event.target.value;
+        applyFilters();
+      });
+
+      levelButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const level = button.dataset.level;
+          if (selectedFilters.levels.has(level)) {
+            selectedFilters.levels.delete(level);
+          } else {
+            selectedFilters.levels.add(level);
+          }
+          applyFilters();
+        });
+      });
+
+      renderProjects(projects);
+      renderActiveFilters();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- replace the placeholder index with a Tailwind-powered card grid of StarryDivineSky repositories
- add realtime search plus multi-select difficulty filters with removable chips
- surface active filters above the grid and show project metadata, topics, and links on each card

## Testing
- Manual: Loaded http://127.0.0.1:8000/index.html and verified filtering and layout

------
https://chatgpt.com/codex/tasks/task_e_68e0a01d5aec83248eea1a7135f48ffa